### PR TITLE
Fix CTFtime API CORS issue with proxy

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -310,7 +310,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     async function fetchCTFtimeData() {
         try {
-            const response = await fetch(`https://ctftime.org/api/v1/teams/${CTFTIME_TEAM_ID}/`);
+            // Use CORS proxy to bypass CORS restrictions
+            const apiUrl = `https://ctftime.org/api/v1/teams/${CTFTIME_TEAM_ID}/`;
+            const corsProxy = 'https://api.allorigins.win/raw?url=';
+            const response = await fetch(corsProxy + encodeURIComponent(apiUrl));
 
             if (!response.ok) {
                 throw new Error('Failed to fetch CTFtime data');


### PR DESCRIPTION
- Add CORS proxy (allorigins.win) to bypass browser restrictions
- CTFtime API doesn't allow direct browser requests from GitHub Pages
- This enables the ranking data to load properly on the live site