### PR TITLE
Verify API call implementation

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -13,17 +13,17 @@ async function fetchCTFEvents() {
 
     try {
         // CTFtime API endpoint for upcoming events
-        const response = await fetch('https://ctftime.org/api/v1/events/', {
-            headers: {
-                'Accept': 'application/json'
-            }
-        });
+        // Use CORS proxy to bypass CORS restrictions
+        const apiUrl = 'https://ctftime.org/api/v1/events/';
+        const corsProxy = 'https://api.allorigins.win/get?url=';
+        const response = await fetch(corsProxy + encodeURIComponent(apiUrl));
 
         if (!response.ok) {
             throw new Error('Failed to fetch events');
         }
 
-        const events = await response.json();
+        const wrapper = await response.json();
+        const events = JSON.parse(wrapper.contents);
         allEvents = events;
 
         loadingElement.style.display = 'none';


### PR DESCRIPTION
The CTFtime API calls were failing due to CORS restrictions when fetching events directly from the browser. Updated calendar.js to use the AllOrigins CORS proxy (same approach used in main.js for team data) to bypass these restrictions and successfully fetch CTF event data.

Changes:
- Added CORS proxy wrapper to API calls in fetchCTFEvents()
- Parse response from proxy wrapper format
- Matches the implementation pattern used in main.js